### PR TITLE
fix(report_lifestory): show report link for non-admin roles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,19 @@
+## [1.0.4] - 2026-04-21
+
+### 🚀 Added
+
+- Add PHPUnit regression test to verify report link visibility for non-admin roles with `report/lifestory:view`
+
+### 🔄 Changed
+
+- Keep the plugin category under Site administration > Reports while using explicit capability checks for access
+
+### ⚠️ Deprecated
+
+### ❌ Removed
+
+### 🐞 Fixed
+
+- Fix report link visibility for non-admin roles by removing `$hassiteconfig` gate and requiring `report/lifestory:view`
+
+### 🔐 Security

--- a/settings.php
+++ b/settings.php
@@ -25,15 +25,16 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-if ($hassiteconfig) {
-    $ADMIN->add('reports', new admin_category(
-        'report_lifestory_cat',
-        get_string('pluginname', 'report_lifestory')
-    ));
+$ADMIN->add('reports', new admin_category(
+    'report_lifestory_cat',
+    get_string('pluginname', 'report_lifestory')
+));
 
-    $ADMIN->add('report_lifestory_cat', new admin_externalpage(
-        'report_lifestory',
-        get_string('lifestory', 'report_lifestory'),
-        new moodle_url('/report/lifestory/index.php')
-    ));
-}
+$ADMIN->add('report_lifestory_cat', new admin_externalpage(
+    'report_lifestory',
+    get_string('lifestory', 'report_lifestory'),
+    new moodle_url('/report/lifestory/index.php'),
+    'report/lifestory:view'
+));
+
+$settings = null;

--- a/tests/settings_test.php
+++ b/tests/settings_test.php
@@ -37,7 +37,6 @@ require_once($CFG->libdir . '/adminlib.php');
  * @category  test
  */
 final class settings_test extends \advanced_testcase {
-
     /**
      * Ensures users with report capability can see the report link without site config capability.
      *

--- a/tests/settings_test.php
+++ b/tests/settings_test.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/.
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for report_lifestory settings visibility.
+ *
+ * @package   report_lifestory
+ * @category  test
+ * @copyright 2026 Datacurso
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace report_lifestory;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir . '/adminlib.php');
+
+/**
+ * Unit tests for report_lifestory admin settings page registration.
+ *
+ * @package   report_lifestory
+ * @category  test
+ */
+final class settings_test extends \advanced_testcase {
+
+    /**
+     * Ensures users with report capability can see the report link without site config capability.
+     *
+     * @coversNothing
+     */
+    public function test_report_link_visible_without_site_config_capability(): void {
+        $this->resetAfterTest(true);
+
+        $context = \context_system::instance();
+        $user = $this->getDataGenerator()->create_user();
+
+        $roleid = create_role('Lifestory viewer', 'lifestoryviewer', 'Role for lifestory report access tests.');
+        assign_capability('report/lifestory:view', CAP_ALLOW, $roleid, $context->id);
+        role_assign($roleid, $user->id, $context->id);
+
+        $this->setUser($user);
+
+        $this->assertFalse(has_capability('moodle/site:config', $context));
+        $this->assertTrue(has_capability('report/lifestory:view', $context));
+
+        $adminroot = admin_get_root(true);
+        $category = $adminroot->locate('report_lifestory_cat');
+        $page = $adminroot->locate('report_lifestory');
+
+        $this->assertInstanceOf('\admin_category', $category);
+        $this->assertInstanceOf('\admin_externalpage', $page);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'report_lifestory';
-$plugin->release = '1.0.3';
-$plugin->version = 2026031200;
+$plugin->release = '1.0.4';
+$plugin->version = 2026042101;
 $plugin->requires = 2024100700;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [405, 501];


### PR DESCRIPTION
### Context

Non-admin users with `report/lifestory:view` could not see the plugin entry in Site administration > Reports because the settings registration was gated by `$hassiteconfig`.

### Description

- Keep the plugin category (`report_lifestory_cat`) under Reports
- Register the external page with explicit capability `report/lifestory:view`
- Remove the `$hassiteconfig` gate so authorized non-admin roles can see the link
- Add a PHPUnit regression test for category/page visibility with a non-admin role
- Add `CHANGES.md` entry and align release metadata in `version.php`

### Steps to review

1. Assign `report/lifestory:view` at system context to a non-admin role/user
2. Log in as that user and go to Site administration > Reports
3. Confirm the `Student Life Story AI` category and report link are visible
4. Confirm users without that capability cannot access the entry

### Checklist

- [x] Scope is clearly defined (report_lifestory plugin)
- [x] Review if the code is covered by tests
- [x] Review if documentation updates are needed
- [ ] Review if backport is needed
- [x] Ensure new entries are added to `CHANGES.md`, if applicable
- [x] Validate plugin version from `version.php`, if applicable

#### Plugin-specific checks (if applicable)

- [x] `CHANGES.md` exists in plugin root
- [x] `version.php` exists in plugin root
- [x] Changelog/version consistency validated from plugin directory

#### UI changes (if applicable)

- [ ] Screenshots/Video included
- [ ] Responsive behavior verified (mobile/tablet/desktop)

### Validation performed

```bash
docker compose -f ../compose.yml exec -T -w /var/www/html company1.moodle vendor/bin/phpunit report/lifestory/tests/settings_test.php
docker compose -f ../compose.yml exec -T -w /var/www/html company1.moodle vendor/bin/phpunit report/lifestory/tests/privacy_provider_test.php
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the project license.